### PR TITLE
Fix brand image receiving and storage

### DIFF
--- a/src/features/brands/components/BrandLogoUploader.tsx
+++ b/src/features/brands/components/BrandLogoUploader.tsx
@@ -19,8 +19,10 @@ import { useI18n } from '@/shared/hooks/useI18n'
 import { uploadSingleImage } from '@/shared/api/files'
 
 type Props = Readonly<{
+    /** Current preview URL */
     value?: string | null
-    onChange: (url?: string | null) => void
+    /** Called with uploaded file info; pass null to clear */
+    onChange: (file: { id?: string | null; url?: string | null } | null) => void
     label?: string
     disabled?: boolean
     maxSizeMB?: number
@@ -84,8 +86,8 @@ export default function BrandLogoUploader({
 
             try {
                 setUploading(true)
-                const url = await uploadSingleImage(file, abortRef.current.signal)
-                onChange(url)
+                const { id, url } = await uploadSingleImage(file, abortRef.current.signal)
+                onChange({ id, url })
                 toast.success(t('uploader.success') || 'Upload completed')
                 URL.revokeObjectURL(objectUrl)
                 setLocalPreview(null)

--- a/src/features/brands/model/types.ts
+++ b/src/features/brands/model/types.ts
@@ -7,6 +7,7 @@ export interface BrandData {
     country?: string | null
     website?: string | null
     logo_url?: string | null
+    logo_id?: string | null
     created_at: string
     updated_at: string
 }
@@ -16,7 +17,7 @@ export interface CreateBrandRequest {
     description?: string
     country?: string
     website?: string
-    logo_url?: string
+    logo_id?: string
 }
 
 export type UpdateBrandRequest = Partial<CreateBrandRequest>

--- a/src/features/brands/pages/EditBrandPage.tsx
+++ b/src/features/brands/pages/EditBrandPage.tsx
@@ -24,7 +24,7 @@ function brandToFormDefaults(b?: BrandData): Partial<CreateBrandRequest> {
         description: b.description ?? '',
         country: b.country ?? '',
         website: b.website ?? '',
-        logo_url: b.logo_url ?? '',
+        logo_id: b.logo_id ?? '',
     }
 }
 
@@ -120,6 +120,7 @@ export default function EditBrandPage(): JSX.Element {
                         <BrandForm
                             key={data.data.id} // اطمینان از ری‌مونت زمانی که رکورد عوض می‌شود
                             defaultValues={formDefaults}
+                            initialLogoUrl={data.data.logo_url ?? ''}
                             onSubmit={(values) => {
                                 setApiErrors([])
                                 update.mutate({ id, payload: values }, {

--- a/src/shared/api/files.ts
+++ b/src/shared/api/files.ts
@@ -11,7 +11,10 @@ export function toAbsoluteUrl(pathOrUrl: string): string {
     return `${base}${pathOrUrl.startsWith('/') ? pathOrUrl : `/${pathOrUrl}`}`
 }
 
-export async function uploadSingleImage(file: File, signal?: AbortSignal): Promise<string> {
+export async function uploadSingleImage(
+    file: File,
+    signal?: AbortSignal,
+): Promise<{ id: string; url: string }> {
     const form = new FormData()
     // Backend accepts `files` as an array; single file upload still uses the same field
     form.append('files', file)
@@ -28,10 +31,10 @@ export async function uploadSingleImage(file: File, signal?: AbortSignal): Promi
     )
 
     const first = data.files?.[0]
-    if (!first || !first.url) {
+    if (!first || !first.url || !first.id) {
         throw new Error('Upload failed: empty response')
     }
-    return toAbsoluteUrl(first.url)
+    return { id: first.id, url: toAbsoluteUrl(first.url) }
 }
 
 export async function uploadFiles(files: File[], signal?: AbortSignal): Promise<string[]> {


### PR DESCRIPTION
Refactor brand image handling to use `logo_id` for API requests while retaining `logo_url` for display.

The previous implementation incorrectly sent `logo_url` to the backend when creating or updating a brand, leading to issues with image association. This change aligns the frontend's data submission with the backend's expectation of a `logo_id` for image references.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa84f656-eaee-4642-a455-ba9e7a71941c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aa84f656-eaee-4642-a455-ba9e7a71941c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

