### PR TITLE
refactor: centralize ApiResponse type

### DIFF
--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -20,7 +20,7 @@ export interface ApiMeta {
 }
 
 /** Generic envelope for all API responses */
-export interface ApiResponse<T> {
+export interface ApiResponse<T = unknown> {
     data: T
     meta: ApiMeta
 }

--- a/src/shared/lib/errors.ts
+++ b/src/shared/lib/errors.ts
@@ -74,14 +74,7 @@ export class RateLimitError extends AppError {
 }
 
 // Standardized API response types
-export interface ApiResponse<T = unknown> {
-    success: boolean
-    data?: T
-    message?: string
-    code?: string
-    errors?: Record<string, string[]>
-    timestamp: string
-}
+export type { ApiResponse } from '../api/types'
 
 export interface ApiErrorResponse {
     success: false


### PR DESCRIPTION
## Summary
- centralize ApiResponse definition in shared api types
- remove duplicate ApiResponse from errors module and re-export unified type
- default ApiResponse generic parameter to unknown

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: A config object has a "plugins" key defined as an array of strings)*
- `npm run format:check` *(warn: Code style issues found in 11 files)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c05995a8832389528307926a2691