### PR TITLE
Serialize params for list query key

### DIFF
--- a/src/shared/api/useCrudQueries.ts
+++ b/src/shared/api/useCrudQueries.ts
@@ -5,9 +5,17 @@ export function createCrudHooks<TData, TCreate, TUpdate>(
     api: ReturnType<typeof import('./crudFactory').createCrudApi<TData, TCreate, TUpdate>>,
 ) {
     return {
+        /**
+         * Retrieve a list of items.
+         *
+         * The `params` argument becomes part of the React Query `queryKey` and is
+         * serialized with `JSON.stringify` for stability. Callers should memoize
+         * `params` (e.g. using `useMemo`) to avoid triggering unnecessary
+         * refetches on each render.
+         */
         useList: (params?: unknown) =>
             useQuery({
-                queryKey: [key, 'list', params],
+                queryKey: [key, 'list', params ? JSON.stringify(params) : undefined],
                 queryFn: () => api.list(params),
             }),
 


### PR DESCRIPTION
## Summary
- serialize `params` when building `useList` query keys
- document that callers should memoize `params` (e.g. with `useMemo`)

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: plugins must be defined as objects in flat config)*
- `npm run format:check` *(fails: code style issues found in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c412df408323a60e560a7322c218