### PR TITLE
feat: generate api client and hooks from openapi spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
                 "eslint-plugin-react-refresh": "^0.4.20",
                 "globals": "^16.3.0",
                 "msw": "^2.10.5",
+                "openapi-typescript-codegen": "^0.29.0",
                 "postcss": "^8.5.6",
                 "prettier": "^3.6.2",
                 "tailwindcss-animate": "^1.0.7",
@@ -87,6 +88,24 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@apidevtools/json-schema-ref-parser": {
+            "version": "11.9.3",
+            "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
+            "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jsdevtools/ono": "^7.1.3",
+                "@types/json-schema": "^7.0.15",
+                "js-yaml": "^4.1.0"
+            },
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/philsturgeon"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1308,6 +1327,13 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@jsdevtools/ono": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+            "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@mswjs/interceptors": {
             "version": "0.39.6",
@@ -3913,6 +3939,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001733",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001733.tgz",
@@ -4054,6 +4093,16 @@
             },
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/commander": {
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/concat-map": {
@@ -4858,6 +4907,31 @@
                 "url": "https://github.com/sponsors/rawify"
             }
         },
+        "node_modules/fs-extra": {
+            "version": "11.3.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+            "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.14"
+            }
+        },
+        "node_modules/fs-extra/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
         "node_modules/fsevents": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5006,6 +5080,28 @@
             "license": "MIT",
             "engines": {
                 "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+            }
+        },
+        "node_modules/handlebars": {
+            "version": "4.7.8",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+            "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimist": "^1.2.5",
+                "neo-async": "^2.6.2",
+                "source-map": "^0.6.1",
+                "wordwrap": "^1.0.0"
+            },
+            "bin": {
+                "handlebars": "bin/handlebars"
+            },
+            "engines": {
+                "node": ">=0.4.7"
+            },
+            "optionalDependencies": {
+                "uglify-js": "^3.1.4"
             }
         },
         "node_modules/has-flag": {
@@ -5287,6 +5383,29 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/jsonfile": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+            "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/jsonfile/node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/keyv": {
@@ -5677,6 +5796,16 @@
                 "node": "*"
             }
         },
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/minipass": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -5800,6 +5929,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/neo-async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/next-themes": {
             "version": "0.4.6",
             "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -5834,6 +5970,23 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/openapi-typescript-codegen": {
+            "version": "0.29.0",
+            "resolved": "https://registry.npmjs.org/openapi-typescript-codegen/-/openapi-typescript-codegen-0.29.0.tgz",
+            "integrity": "sha512-/wC42PkD0LGjDTEULa/XiWQbv4E9NwLjwLjsaJ/62yOsoYhwvmBR31kPttn1DzQ2OlGe5stACcF/EIkZk43M6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@apidevtools/json-schema-ref-parser": "^11.5.4",
+                "camelcase": "^6.3.0",
+                "commander": "^12.0.0",
+                "fs-extra": "^11.2.0",
+                "handlebars": "^4.7.8"
+            },
+            "bin": {
+                "openapi": "bin/index.js"
             }
         },
         "node_modules/optionator": {
@@ -6518,6 +6671,16 @@
                 "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
             }
         },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6845,6 +7008,20 @@
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },
+        "node_modules/uglify-js": {
+            "version": "3.19.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+            "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "optional": true,
+            "bin": {
+                "uglifyjs": "bin/uglifyjs"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
         "node_modules/undici-types": {
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
@@ -7135,6 +7312,13 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/wrap-ansi": {
             "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
         "preview": "vite preview",
         "lint": "eslint .",
         "format": "prettier --write .",
-        "format:check": "prettier --check ."
+        "format:check": "prettier --check .",
+        "generate:api": "node scripts/generate-api.mjs"
     },
     "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -78,6 +79,7 @@
         "tw-animate-css": "^1.3.6",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.39.0",
-        "vite": "^7.1.0"
+        "vite": "^7.1.0",
+        "openapi-typescript-codegen": "^0.29.0"
     }
 }

--- a/scripts/generate-api.mjs
+++ b/scripts/generate-api.mjs
@@ -1,0 +1,55 @@
+import { execSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { generate } from 'openapi-typescript-codegen'
+
+const SPEC_URL = process.env.API_SPEC_URL || 'https://petstore3.swagger.io/api/v3/openapi.json'
+const OUTPUT_DIR = path.resolve('src/shared/api/generated')
+const TMP_SPEC = path.resolve('tmp/openapi.json')
+
+execSync(`mkdir -p ${path.dirname(TMP_SPEC)}`)
+execSync(`curl -s ${SPEC_URL} -o ${TMP_SPEC}`)
+
+await generate({
+    input: TMP_SPEC,
+    output: OUTPUT_DIR,
+    httpClient: 'axios',
+    useOptions: true,
+    exportCore: true,
+    exportServices: true,
+    exportModels: true,
+})
+
+const spec = JSON.parse(fs.readFileSync(TMP_SPEC, 'utf-8'))
+const resources = []
+for (const route of Object.keys(spec.paths)) {
+    const match = route.match(/^\/([^\/]+)$/)
+    if (!match) continue
+    const name = match[1]
+    const idPathReg = new RegExp(`^/${name}/\\{`)
+    if (!Object.keys(spec.paths).some((p) => idPathReg.test(p))) continue
+    let type = 'any'
+    const detailPath = Object.keys(spec.paths).find((p) => idPathReg.test(p) && spec.paths[p].get)
+    if (detailPath) {
+        const schema =
+            spec.paths[detailPath].get?.responses?.['200']?.content?.['application/json']?.schema
+        if (schema?.$ref) type = schema.$ref.split('/').pop()
+    }
+    resources.push({ name, type })
+}
+
+const capitalize = (s) => s.charAt(0).toUpperCase() + s.slice(1)
+let content = `/* eslint-disable */\nimport { apiClient } from '@/lib/axios';\nimport { createCrudApi } from '../crudFactory';\nimport { createCrudHooks } from '../useCrudQueries';\n`
+for (const r of resources) {
+    if (r.type !== 'any') {
+        content += `import type { ${r.type} } from './models/${r.type}';\n`
+    }
+}
+content += '\n'
+for (const r of resources) {
+    const Type = r.type !== 'any' ? r.type : 'any'
+    const cap = capitalize(r.name)
+    content += `const ${r.name}Api = createCrudApi<${Type}, ${Type}, Partial<${Type}>>(apiClient, '/${r.name}');\n`
+    content += `export const { useList: use${cap}List, useDetail: use${cap}Detail, useCreate: use${cap}Create, useUpdate: use${cap}Update, useDelete: use${cap}Delete } = createCrudHooks<${Type}, ${Type}, Partial<${Type}>>('${r.name}', ${r.name}Api);\n\n`
+}
+fs.writeFileSync(path.join(OUTPUT_DIR, 'hooks.ts'), content)

--- a/src/shared/api/generated/core/ApiError.ts
+++ b/src/shared/api/generated/core/ApiError.ts
@@ -1,0 +1,25 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+
+export class ApiError extends Error {
+    public readonly url: string;
+    public readonly status: number;
+    public readonly statusText: string;
+    public readonly body: any;
+    public readonly request: ApiRequestOptions;
+
+    constructor(request: ApiRequestOptions, response: ApiResult, message: string) {
+        super(message);
+
+        this.name = 'ApiError';
+        this.url = response.url;
+        this.status = response.status;
+        this.statusText = response.statusText;
+        this.body = response.body;
+        this.request = request;
+    }
+}

--- a/src/shared/api/generated/core/ApiRequestOptions.ts
+++ b/src/shared/api/generated/core/ApiRequestOptions.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApiRequestOptions = {
+    readonly method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH';
+    readonly url: string;
+    readonly path?: Record<string, any>;
+    readonly cookies?: Record<string, any>;
+    readonly headers?: Record<string, any>;
+    readonly query?: Record<string, any>;
+    readonly formData?: Record<string, any>;
+    readonly body?: any;
+    readonly mediaType?: string;
+    readonly responseHeader?: string;
+    readonly errors?: Record<number, string>;
+};

--- a/src/shared/api/generated/core/ApiResult.ts
+++ b/src/shared/api/generated/core/ApiResult.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApiResult = {
+    readonly url: string;
+    readonly ok: boolean;
+    readonly status: number;
+    readonly statusText: string;
+    readonly body: any;
+};

--- a/src/shared/api/generated/core/CancelablePromise.ts
+++ b/src/shared/api/generated/core/CancelablePromise.ts
@@ -1,0 +1,131 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export class CancelError extends Error {
+
+    constructor(message: string) {
+        super(message);
+        this.name = 'CancelError';
+    }
+
+    public get isCancelled(): boolean {
+        return true;
+    }
+}
+
+export interface OnCancel {
+    readonly isResolved: boolean;
+    readonly isRejected: boolean;
+    readonly isCancelled: boolean;
+
+    (cancelHandler: () => void): void;
+}
+
+export class CancelablePromise<T> implements Promise<T> {
+    #isResolved: boolean;
+    #isRejected: boolean;
+    #isCancelled: boolean;
+    readonly #cancelHandlers: (() => void)[];
+    readonly #promise: Promise<T>;
+    #resolve?: (value: T | PromiseLike<T>) => void;
+    #reject?: (reason?: any) => void;
+
+    constructor(
+        executor: (
+            resolve: (value: T | PromiseLike<T>) => void,
+            reject: (reason?: any) => void,
+            onCancel: OnCancel
+        ) => void
+    ) {
+        this.#isResolved = false;
+        this.#isRejected = false;
+        this.#isCancelled = false;
+        this.#cancelHandlers = [];
+        this.#promise = new Promise<T>((resolve, reject) => {
+            this.#resolve = resolve;
+            this.#reject = reject;
+
+            const onResolve = (value: T | PromiseLike<T>): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#isResolved = true;
+                if (this.#resolve) this.#resolve(value);
+            };
+
+            const onReject = (reason?: any): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#isRejected = true;
+                if (this.#reject) this.#reject(reason);
+            };
+
+            const onCancel = (cancelHandler: () => void): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#cancelHandlers.push(cancelHandler);
+            };
+
+            Object.defineProperty(onCancel, 'isResolved', {
+                get: (): boolean => this.#isResolved,
+            });
+
+            Object.defineProperty(onCancel, 'isRejected', {
+                get: (): boolean => this.#isRejected,
+            });
+
+            Object.defineProperty(onCancel, 'isCancelled', {
+                get: (): boolean => this.#isCancelled,
+            });
+
+            return executor(onResolve, onReject, onCancel as OnCancel);
+        });
+    }
+
+    get [Symbol.toStringTag]() {
+        return "Cancellable Promise";
+    }
+
+    public then<TResult1 = T, TResult2 = never>(
+        onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+        onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
+    ): Promise<TResult1 | TResult2> {
+        return this.#promise.then(onFulfilled, onRejected);
+    }
+
+    public catch<TResult = never>(
+        onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null
+    ): Promise<T | TResult> {
+        return this.#promise.catch(onRejected);
+    }
+
+    public finally(onFinally?: (() => void) | null): Promise<T> {
+        return this.#promise.finally(onFinally);
+    }
+
+    public cancel(): void {
+        if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+            return;
+        }
+        this.#isCancelled = true;
+        if (this.#cancelHandlers.length) {
+            try {
+                for (const cancelHandler of this.#cancelHandlers) {
+                    cancelHandler();
+                }
+            } catch (error) {
+                console.warn('Cancellation threw an error', error);
+                return;
+            }
+        }
+        this.#cancelHandlers.length = 0;
+        if (this.#reject) this.#reject(new CancelError('Request aborted'));
+    }
+
+    public get isCancelled(): boolean {
+        return this.#isCancelled;
+    }
+}

--- a/src/shared/api/generated/core/OpenAPI.ts
+++ b/src/shared/api/generated/core/OpenAPI.ts
@@ -1,0 +1,32 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiRequestOptions } from './ApiRequestOptions';
+
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+type Headers = Record<string, string>;
+
+export type OpenAPIConfig = {
+    BASE: string;
+    VERSION: string;
+    WITH_CREDENTIALS: boolean;
+    CREDENTIALS: 'include' | 'omit' | 'same-origin';
+    TOKEN?: string | Resolver<string> | undefined;
+    USERNAME?: string | Resolver<string> | undefined;
+    PASSWORD?: string | Resolver<string> | undefined;
+    HEADERS?: Headers | Resolver<Headers> | undefined;
+    ENCODE_PATH?: ((path: string) => string) | undefined;
+};
+
+export const OpenAPI: OpenAPIConfig = {
+    BASE: '/api/v3',
+    VERSION: '1.0.27',
+    WITH_CREDENTIALS: false,
+    CREDENTIALS: 'include',
+    TOKEN: undefined,
+    USERNAME: undefined,
+    PASSWORD: undefined,
+    HEADERS: undefined,
+    ENCODE_PATH: undefined,
+};

--- a/src/shared/api/generated/core/request.ts
+++ b/src/shared/api/generated/core/request.ts
@@ -1,0 +1,323 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import axios from 'axios';
+import type { AxiosError, AxiosRequestConfig, AxiosResponse, AxiosInstance } from 'axios';
+import FormData from 'form-data';
+
+import { ApiError } from './ApiError';
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+import { CancelablePromise } from './CancelablePromise';
+import type { OnCancel } from './CancelablePromise';
+import type { OpenAPIConfig } from './OpenAPI';
+
+export const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
+    return value !== undefined && value !== null;
+};
+
+export const isString = (value: any): value is string => {
+    return typeof value === 'string';
+};
+
+export const isStringWithValue = (value: any): value is string => {
+    return isString(value) && value !== '';
+};
+
+export const isBlob = (value: any): value is Blob => {
+    return (
+        typeof value === 'object' &&
+        typeof value.type === 'string' &&
+        typeof value.stream === 'function' &&
+        typeof value.arrayBuffer === 'function' &&
+        typeof value.constructor === 'function' &&
+        typeof value.constructor.name === 'string' &&
+        /^(Blob|File)$/.test(value.constructor.name) &&
+        /^(Blob|File)$/.test(value[Symbol.toStringTag])
+    );
+};
+
+export const isFormData = (value: any): value is FormData => {
+    return value instanceof FormData;
+};
+
+export const isSuccess = (status: number): boolean => {
+    return status >= 200 && status < 300;
+};
+
+export const base64 = (str: string): string => {
+    try {
+        return btoa(str);
+    } catch (err) {
+        // @ts-ignore
+        return Buffer.from(str).toString('base64');
+    }
+};
+
+export const getQueryString = (params: Record<string, any>): string => {
+    const qs: string[] = [];
+
+    const append = (key: string, value: any) => {
+        qs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+    };
+
+    const process = (key: string, value: any) => {
+        if (isDefined(value)) {
+            if (Array.isArray(value)) {
+                value.forEach(v => {
+                    process(key, v);
+                });
+            } else if (typeof value === 'object') {
+                Object.entries(value).forEach(([k, v]) => {
+                    process(`${key}[${k}]`, v);
+                });
+            } else {
+                append(key, value);
+            }
+        }
+    };
+
+    Object.entries(params).forEach(([key, value]) => {
+        process(key, value);
+    });
+
+    if (qs.length > 0) {
+        return `?${qs.join('&')}`;
+    }
+
+    return '';
+};
+
+const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
+    const encoder = config.ENCODE_PATH || encodeURI;
+
+    const path = options.url
+        .replace('{api-version}', config.VERSION)
+        .replace(/{(.*?)}/g, (substring: string, group: string) => {
+            if (options.path?.hasOwnProperty(group)) {
+                return encoder(String(options.path[group]));
+            }
+            return substring;
+        });
+
+    const url = `${config.BASE}${path}`;
+    if (options.query) {
+        return `${url}${getQueryString(options.query)}`;
+    }
+    return url;
+};
+
+export const getFormData = (options: ApiRequestOptions): FormData | undefined => {
+    if (options.formData) {
+        const formData = new FormData();
+
+        const process = (key: string, value: any) => {
+            if (isString(value) || isBlob(value)) {
+                formData.append(key, value);
+            } else {
+                formData.append(key, JSON.stringify(value));
+            }
+        };
+
+        Object.entries(options.formData)
+            .filter(([_, value]) => isDefined(value))
+            .forEach(([key, value]) => {
+                if (Array.isArray(value)) {
+                    value.forEach(v => process(key, v));
+                } else {
+                    process(key, value);
+                }
+            });
+
+        return formData;
+    }
+    return undefined;
+};
+
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+
+export const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
+    if (typeof resolver === 'function') {
+        return (resolver as Resolver<T>)(options);
+    }
+    return resolver;
+};
+
+export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions, formData?: FormData): Promise<Record<string, string>> => {
+    const [token, username, password, additionalHeaders] = await Promise.all([
+        resolve(options, config.TOKEN),
+        resolve(options, config.USERNAME),
+        resolve(options, config.PASSWORD),
+        resolve(options, config.HEADERS),
+    ]);
+
+    const formHeaders = typeof formData?.getHeaders === 'function' && formData?.getHeaders() || {}
+
+    const headers = Object.entries({
+        Accept: 'application/json',
+        ...additionalHeaders,
+        ...options.headers,
+        ...formHeaders,
+    })
+    .filter(([_, value]) => isDefined(value))
+    .reduce((headers, [key, value]) => ({
+        ...headers,
+        [key]: String(value),
+    }), {} as Record<string, string>);
+
+    if (isStringWithValue(token)) {
+        headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (isStringWithValue(username) && isStringWithValue(password)) {
+        const credentials = base64(`${username}:${password}`);
+        headers['Authorization'] = `Basic ${credentials}`;
+    }
+
+    if (options.body !== undefined) {
+        if (options.mediaType) {
+            headers['Content-Type'] = options.mediaType;
+        } else if (isBlob(options.body)) {
+            headers['Content-Type'] = options.body.type || 'application/octet-stream';
+        } else if (isString(options.body)) {
+            headers['Content-Type'] = 'text/plain';
+        } else if (!isFormData(options.body)) {
+            headers['Content-Type'] = 'application/json';
+        }
+    }
+
+    return headers;
+};
+
+export const getRequestBody = (options: ApiRequestOptions): any => {
+    if (options.body) {
+        return options.body;
+    }
+    return undefined;
+};
+
+export const sendRequest = async <T>(
+    config: OpenAPIConfig,
+    options: ApiRequestOptions,
+    url: string,
+    body: any,
+    formData: FormData | undefined,
+    headers: Record<string, string>,
+    onCancel: OnCancel,
+    axiosClient: AxiosInstance
+): Promise<AxiosResponse<T>> => {
+    const source = axios.CancelToken.source();
+
+    const requestConfig: AxiosRequestConfig = {
+        url,
+        headers,
+        data: body ?? formData,
+        method: options.method,
+        withCredentials: config.WITH_CREDENTIALS,
+        withXSRFToken: config.CREDENTIALS === 'include' ? config.WITH_CREDENTIALS : false,
+        cancelToken: source.token,
+    };
+
+    onCancel(() => source.cancel('The user aborted a request.'));
+
+    try {
+        return await axiosClient.request(requestConfig);
+    } catch (error) {
+        const axiosError = error as AxiosError<T>;
+        if (axiosError.response) {
+            return axiosError.response;
+        }
+        throw error;
+    }
+};
+
+export const getResponseHeader = (response: AxiosResponse<any>, responseHeader?: string): string | undefined => {
+    if (responseHeader) {
+        const content = response.headers[responseHeader];
+        if (isString(content)) {
+            return content;
+        }
+    }
+    return undefined;
+};
+
+export const getResponseBody = (response: AxiosResponse<any>): any => {
+    if (response.status !== 204) {
+        return response.data;
+    }
+    return undefined;
+};
+
+export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
+    const errors: Record<number, string> = {
+        400: 'Bad Request',
+        401: 'Unauthorized',
+        403: 'Forbidden',
+        404: 'Not Found',
+        500: 'Internal Server Error',
+        502: 'Bad Gateway',
+        503: 'Service Unavailable',
+        ...options.errors,
+    }
+
+    const error = errors[result.status];
+    if (error) {
+        throw new ApiError(options, result, error);
+    }
+
+    if (!result.ok) {
+        const errorStatus = result.status ?? 'unknown';
+        const errorStatusText = result.statusText ?? 'unknown';
+        const errorBody = (() => {
+            try {
+                return JSON.stringify(result.body, null, 2);
+            } catch (e) {
+                return undefined;
+            }
+        })();
+
+        throw new ApiError(options, result,
+            `Generic Error: status: ${errorStatus}; status text: ${errorStatusText}; body: ${errorBody}`
+        );
+    }
+};
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param options The request options from the service
+ * @param axiosClient The axios client instance to use
+ * @returns CancelablePromise<T>
+ * @throws ApiError
+ */
+export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions, axiosClient: AxiosInstance = axios): CancelablePromise<T> => {
+    return new CancelablePromise(async (resolve, reject, onCancel) => {
+        try {
+            const url = getUrl(config, options);
+            const formData = getFormData(options);
+            const body = getRequestBody(options);
+            const headers = await getHeaders(config, options, formData);
+
+            if (!onCancel.isCancelled) {
+                const response = await sendRequest<T>(config, options, url, body, formData, headers, onCancel, axiosClient);
+                const responseBody = getResponseBody(response);
+                const responseHeader = getResponseHeader(response, options.responseHeader);
+
+                const result: ApiResult = {
+                    url,
+                    ok: isSuccess(response.status),
+                    status: response.status,
+                    statusText: response.statusText,
+                    body: responseHeader ?? responseBody,
+                };
+
+                catchErrorCodes(options, result);
+
+                resolve(result.body);
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
+};

--- a/src/shared/api/generated/hooks.ts
+++ b/src/shared/api/generated/hooks.ts
@@ -1,0 +1,25 @@
+/* eslint-disable */
+import { apiClient } from '@/lib/axios'
+
+import { createCrudApi } from '../crudFactory'
+import { createCrudHooks } from '../useCrudQueries'
+import type { Pet } from './models/Pet'
+import type { User } from './models/User'
+
+const petApi = createCrudApi<Pet, Pet, Partial<Pet>>(apiClient, '/pet')
+export const {
+    useList: usePetList,
+    useDetail: usePetDetail,
+    useCreate: usePetCreate,
+    useUpdate: usePetUpdate,
+    useDelete: usePetDelete,
+} = createCrudHooks<Pet, Pet, Partial<Pet>>('pet', petApi)
+
+const userApi = createCrudApi<User, User, Partial<User>>(apiClient, '/user')
+export const {
+    useList: useUserList,
+    useDetail: useUserDetail,
+    useCreate: useUserCreate,
+    useUpdate: useUserUpdate,
+    useDelete: useUserDelete,
+} = createCrudHooks<User, User, Partial<User>>('user', userApi)

--- a/src/shared/api/generated/index.ts
+++ b/src/shared/api/generated/index.ts
@@ -1,0 +1,19 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export { ApiError } from './core/ApiError';
+export { CancelablePromise, CancelError } from './core/CancelablePromise';
+export { OpenAPI } from './core/OpenAPI';
+export type { OpenAPIConfig } from './core/OpenAPI';
+
+export type { ApiResponse } from './models/ApiResponse';
+export type { Category } from './models/Category';
+export { Order } from './models/Order';
+export { Pet } from './models/Pet';
+export type { Tag } from './models/Tag';
+export type { User } from './models/User';
+
+export { PetService } from './services/PetService';
+export { StoreService } from './services/StoreService';
+export { UserService } from './services/UserService';

--- a/src/shared/api/generated/models/ApiResponse.ts
+++ b/src/shared/api/generated/models/ApiResponse.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApiResponse = {
+    code?: number;
+    type?: string;
+    message?: string;
+};
+

--- a/src/shared/api/generated/models/Category.ts
+++ b/src/shared/api/generated/models/Category.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type Category = {
+    id?: number;
+    name?: string;
+};
+

--- a/src/shared/api/generated/models/Order.ts
+++ b/src/shared/api/generated/models/Order.ts
@@ -1,0 +1,26 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type Order = {
+    id?: number;
+    petId?: number;
+    quantity?: number;
+    shipDate?: string;
+    /**
+     * Order Status
+     */
+    status?: Order.status;
+    complete?: boolean;
+};
+export namespace Order {
+    /**
+     * Order Status
+     */
+    export enum status {
+        PLACED = 'placed',
+        APPROVED = 'approved',
+        DELIVERED = 'delivered',
+    }
+}
+

--- a/src/shared/api/generated/models/Pet.ts
+++ b/src/shared/api/generated/models/Pet.ts
@@ -1,0 +1,28 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { Category } from './Category';
+import type { Tag } from './Tag';
+export type Pet = {
+    id?: number;
+    name: string;
+    category?: Category;
+    photoUrls: Array<string>;
+    tags?: Array<Tag>;
+    /**
+     * pet status in the store
+     */
+    status?: Pet.status;
+};
+export namespace Pet {
+    /**
+     * pet status in the store
+     */
+    export enum status {
+        AVAILABLE = 'available',
+        PENDING = 'pending',
+        SOLD = 'sold',
+    }
+}
+

--- a/src/shared/api/generated/models/Tag.ts
+++ b/src/shared/api/generated/models/Tag.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type Tag = {
+    id?: number;
+    name?: string;
+};
+

--- a/src/shared/api/generated/models/User.ts
+++ b/src/shared/api/generated/models/User.ts
@@ -1,0 +1,18 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type User = {
+    id?: number;
+    username?: string;
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+    password?: string;
+    phone?: string;
+    /**
+     * User Status
+     */
+    userStatus?: number;
+};
+

--- a/src/shared/api/generated/services/PetService.ts
+++ b/src/shared/api/generated/services/PetService.ts
@@ -1,0 +1,252 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiResponse } from '../models/ApiResponse';
+import type { Pet } from '../models/Pet';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class PetService {
+    /**
+     * Update an existing pet.
+     * Update an existing pet by Id.
+     * @returns Pet Successful operation
+     * @returns any Unexpected error
+     * @throws ApiError
+     */
+    public static updatePet({
+        requestBody,
+    }: {
+        /**
+         * Update an existent pet in the store
+         */
+        requestBody: Pet,
+    }): CancelablePromise<Pet | any> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/pet',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                400: `Invalid ID supplied`,
+                404: `Pet not found`,
+                422: `Validation exception`,
+            },
+        });
+    }
+    /**
+     * Add a new pet to the store.
+     * Add a new pet to the store.
+     * @returns Pet Successful operation
+     * @returns any Unexpected error
+     * @throws ApiError
+     */
+    public static addPet({
+        requestBody,
+    }: {
+        /**
+         * Create a new pet in the store
+         */
+        requestBody: Pet,
+    }): CancelablePromise<Pet | any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/pet',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                400: `Invalid input`,
+                422: `Validation exception`,
+            },
+        });
+    }
+    /**
+     * Finds Pets by status.
+     * Multiple status values can be provided with comma separated strings.
+     * @returns Pet successful operation
+     * @returns any Unexpected error
+     * @throws ApiError
+     */
+    public static findPetsByStatus({
+        status = 'available',
+    }: {
+        /**
+         * Status values that need to be considered for filter
+         */
+        status?: 'available' | 'pending' | 'sold',
+    }): CancelablePromise<Array<Pet> | any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/pet/findByStatus',
+            query: {
+                'status': status,
+            },
+            errors: {
+                400: `Invalid status value`,
+            },
+        });
+    }
+    /**
+     * Finds Pets by tags.
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * @returns Pet successful operation
+     * @returns any Unexpected error
+     * @throws ApiError
+     */
+    public static findPetsByTags({
+        tags,
+    }: {
+        /**
+         * Tags to filter by
+         */
+        tags: Array<string>,
+    }): CancelablePromise<Array<Pet> | any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/pet/findByTags',
+            query: {
+                'tags': tags,
+            },
+            errors: {
+                400: `Invalid tag value`,
+            },
+        });
+    }
+    /**
+     * Find pet by ID.
+     * Returns a single pet.
+     * @returns Pet successful operation
+     * @returns any Unexpected error
+     * @throws ApiError
+     */
+    public static getPetById({
+        petId,
+    }: {
+        /**
+         * ID of pet to return
+         */
+        petId: number,
+    }): CancelablePromise<Pet | any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/pet/{petId}',
+            path: {
+                'petId': petId,
+            },
+            errors: {
+                400: `Invalid ID supplied`,
+                404: `Pet not found`,
+            },
+        });
+    }
+    /**
+     * Updates a pet in the store with form data.
+     * Updates a pet resource based on the form data.
+     * @returns Pet successful operation
+     * @returns any Unexpected error
+     * @throws ApiError
+     */
+    public static updatePetWithForm({
+        petId,
+        name,
+        status,
+    }: {
+        /**
+         * ID of pet that needs to be updated
+         */
+        petId: number,
+        /**
+         * Name of pet that needs to be updated
+         */
+        name?: string,
+        /**
+         * Status of pet that needs to be updated
+         */
+        status?: string,
+    }): CancelablePromise<Pet | any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/pet/{petId}',
+            path: {
+                'petId': petId,
+            },
+            query: {
+                'name': name,
+                'status': status,
+            },
+            errors: {
+                400: `Invalid input`,
+            },
+        });
+    }
+    /**
+     * Deletes a pet.
+     * Delete a pet.
+     * @returns any Pet deleted
+     * @throws ApiError
+     */
+    public static deletePet({
+        petId,
+        apiKey,
+    }: {
+        /**
+         * Pet id to delete
+         */
+        petId: number,
+        apiKey?: string,
+    }): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/pet/{petId}',
+            path: {
+                'petId': petId,
+            },
+            headers: {
+                'api_key': apiKey,
+            },
+            errors: {
+                400: `Invalid pet value`,
+            },
+        });
+    }
+    /**
+     * Uploads an image.
+     * Upload image of the pet.
+     * @returns ApiResponse successful operation
+     * @returns any Unexpected error
+     * @throws ApiError
+     */
+    public static uploadFile({
+        petId,
+        additionalMetadata,
+        requestBody,
+    }: {
+        /**
+         * ID of pet to update
+         */
+        petId: number,
+        /**
+         * Additional Metadata
+         */
+        additionalMetadata?: string,
+        requestBody?: Blob,
+    }): CancelablePromise<ApiResponse | any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/pet/{petId}/uploadImage',
+            path: {
+                'petId': petId,
+            },
+            query: {
+                'additionalMetadata': additionalMetadata,
+            },
+            body: requestBody,
+            mediaType: 'application/octet-stream',
+            errors: {
+                400: `No file uploaded`,
+                404: `Pet not found`,
+            },
+        });
+    }
+}

--- a/src/shared/api/generated/services/StoreService.ts
+++ b/src/shared/api/generated/services/StoreService.ts
@@ -1,0 +1,99 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { Order } from '../models/Order';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class StoreService {
+    /**
+     * Returns pet inventories by status.
+     * Returns a map of status codes to quantities.
+     * @returns number successful operation
+     * @returns any Unexpected error
+     * @throws ApiError
+     */
+    public static getInventory(): CancelablePromise<Record<string, number> | any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/store/inventory',
+        });
+    }
+    /**
+     * Place an order for a pet.
+     * Place a new order in the store.
+     * @returns Order successful operation
+     * @returns any Unexpected error
+     * @throws ApiError
+     */
+    public static placeOrder({
+        requestBody,
+    }: {
+        requestBody?: Order,
+    }): CancelablePromise<Order | any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/store/order',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                400: `Invalid input`,
+                422: `Validation exception`,
+            },
+        });
+    }
+    /**
+     * Find purchase order by ID.
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.
+     * @returns Order successful operation
+     * @returns any Unexpected error
+     * @throws ApiError
+     */
+    public static getOrderById({
+        orderId,
+    }: {
+        /**
+         * ID of order that needs to be fetched
+         */
+        orderId: number,
+    }): CancelablePromise<Order | any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/store/order/{orderId}',
+            path: {
+                'orderId': orderId,
+            },
+            errors: {
+                400: `Invalid ID supplied`,
+                404: `Order not found`,
+            },
+        });
+    }
+    /**
+     * Delete purchase order by identifier.
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or non-integers will generate API errors.
+     * @returns any order deleted
+     * @throws ApiError
+     */
+    public static deleteOrder({
+        orderId,
+    }: {
+        /**
+         * ID of the order that needs to be deleted
+         */
+        orderId: number,
+    }): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/store/order/{orderId}',
+            path: {
+                'orderId': orderId,
+            },
+            errors: {
+                400: `Invalid ID supplied`,
+                404: `Order not found`,
+            },
+        });
+    }
+}

--- a/src/shared/api/generated/services/UserService.ts
+++ b/src/shared/api/generated/services/UserService.ts
@@ -1,0 +1,181 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { User } from '../models/User';
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class UserService {
+    /**
+     * Create user.
+     * This can only be done by the logged in user.
+     * @returns User successful operation
+     * @returns any Unexpected error
+     * @throws ApiError
+     */
+    public static createUser({
+        requestBody,
+    }: {
+        /**
+         * Created user object
+         */
+        requestBody?: User,
+    }): CancelablePromise<User | any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/user',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
+     * Creates list of users with given input array.
+     * Creates list of users with given input array.
+     * @returns User Successful operation
+     * @returns any Unexpected error
+     * @throws ApiError
+     */
+    public static createUsersWithListInput({
+        requestBody,
+    }: {
+        requestBody?: Array<User>,
+    }): CancelablePromise<User | any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/user/createWithList',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
+     * Logs user into the system.
+     * Log into the system.
+     * @returns string successful operation
+     * @returns any Unexpected error
+     * @throws ApiError
+     */
+    public static loginUser({
+        username,
+        password,
+    }: {
+        /**
+         * The user name for login
+         */
+        username?: string,
+        /**
+         * The password for login in clear text
+         */
+        password?: string,
+    }): CancelablePromise<string | any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/user/login',
+            query: {
+                'username': username,
+                'password': password,
+            },
+            errors: {
+                400: `Invalid username/password supplied`,
+            },
+        });
+    }
+    /**
+     * Logs out current logged in user session.
+     * Log user out of the system.
+     * @returns any successful operation
+     * @throws ApiError
+     */
+    public static logoutUser(): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/user/logout',
+        });
+    }
+    /**
+     * Get user by user name.
+     * Get user detail based on username.
+     * @returns User successful operation
+     * @returns any Unexpected error
+     * @throws ApiError
+     */
+    public static getUserByName({
+        username,
+    }: {
+        /**
+         * The name that needs to be fetched. Use user1 for testing
+         */
+        username: string,
+    }): CancelablePromise<User | any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/user/{username}',
+            path: {
+                'username': username,
+            },
+            errors: {
+                400: `Invalid username supplied`,
+                404: `User not found`,
+            },
+        });
+    }
+    /**
+     * Update user resource.
+     * This can only be done by the logged in user.
+     * @returns any successful operation
+     * @throws ApiError
+     */
+    public static updateUser({
+        username,
+        requestBody,
+    }: {
+        /**
+         * name that need to be deleted
+         */
+        username: string,
+        /**
+         * Update an existent user in the store
+         */
+        requestBody?: User,
+    }): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/user/{username}',
+            path: {
+                'username': username,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                400: `bad request`,
+                404: `user not found`,
+            },
+        });
+    }
+    /**
+     * Delete user resource.
+     * This can only be done by the logged in user.
+     * @returns any User deleted
+     * @throws ApiError
+     */
+    public static deleteUser({
+        username,
+    }: {
+        /**
+         * The name that needs to be deleted
+         */
+        username: string,
+    }): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/user/{username}',
+            path: {
+                'username': username,
+            },
+            errors: {
+                400: `Invalid username supplied`,
+                404: `User not found`,
+            },
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- generate OpenAPI client and CRUD hooks using `openapi-typescript-codegen`
- add script `generate-api` to download spec and build TypeScript API layer
- expose `useList`, `useDetail`, `useCreate`, `useUpdate`, `useDelete` hooks per model

## Testing
- `npm run generate:api`
- `npm run lint` *(fails: A config object has a "plugins" key defined as an array of strings)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4c89a7c008323a1d55285fa519e08